### PR TITLE
Add Aux input, temperature reads, fix battery voltage read, fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change log for esp_lcd_touch_xpt2046
 
+## v1.0.4 - New features
+
+* Add ability to read voltage level from Aux pin.
+* Add ability to read temperature using the TEMP0 register (one point mode).
+* Add ability to read temperature using the TEMP0 and TEMP1 registers (two point mode).
+* Enable PENIRQ pin output when touched (if configured).
+* Enable use of PENIRQ input to test for touch (if PENIRQ input pin configured).
+* Allow leaving Vref permanently on (if configured). Increases power usage but reduces SPI transactions for temperature and voltage reads.
+* Fixes battery voltage read (was scaled incorrectly).
+* Fixes coordinate averaging (fix random bad clicks).
+* Adjusts Vref voltage to reflect value in typical usage conditions.
+
 ## v1.0.3 - Minor Bug fixes
 
 * Add new parameters to ESP_LCD_TOUCH_IO_SPI_XPT2046_CONFIG macro based on IDF v5.1.2 and v5.1.3+.

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -6,6 +6,24 @@ menu "XPT2046"
             Touch pressure less than this value will be discarded as invalid
             and no touch position data collected.
 
+    config XPT2046_INTERRUPT_MODE
+        bool "Enable Interrupt (PENIRQ) output"
+        default n
+        help
+            Also called Full Power Mode.
+            Enable this to configure the XPT2046 to output low on the PENIRQ output
+            if a touch is detected.
+            This mode uses more power when enabled.
+            Note that this signal goes low normally when a read is active.
+
+    config XPT2046_VREF_ON_MODE
+        bool "Keep internal Vref enabled"
+        default n
+        help
+            Enable this to keep the internal Vref enabled between conversions.
+            This uses slightly more power, but requires fewer transactions when
+            reading the battery voltage, aux voltage and temperature.
+
     config XPT2046_CONVERT_ADC_TO_COORDS
         bool "Convert touch coordinates to screen coordinates"
         default y

--- a/esp_lcd_touch_xpt2046.c
+++ b/esp_lcd_touch_xpt2046.c
@@ -56,9 +56,12 @@ enum xpt2046_registers
 #define XPT2046_UNLOCK(lock)
 #endif
 
-#define XPT2046_TEMP0_COUNTS_AT_25C   (599.5 / 2507 * 4096)
-
 static const uint16_t XPT2046_ADC_LIMIT = 4096;
+// refer the TSC2046 datasheet https://www.ti.com/lit/ds/symlink/tsc2046.pdf rev F 2008
+// TEMP0 reads approx 599.5 mV at 25C (Refer p8 TEMP0 diode voltage vs Vcc chart)
+// Vref is approx 2.507V = 2507mV at moderate temperatures (refer p8 Vref vs Temperature chart)
+// counts@25C = TEMP0_mV / Vref_mv * XPT2046_ADC_LIMIT
+static const float XPT2046_TEMP0_COUNTS_AT_25C = (599.5 / 2507 * XPT2046_ADC_LIMIT);
 static esp_err_t xpt2046_read_data(esp_lcd_touch_handle_t tp);
 static bool xpt2046_get_xy(esp_lcd_touch_handle_t tp,
                            uint16_t *x, uint16_t *y,

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -3,4 +3,4 @@ dependencies:
   esp_lcd_touch: ">=1.0.4"
 description: esp_lcd_touch driver for XPT2046 touch controllers.
 url: https://github.com/atanisoft/esp_lcd_touch_xpt2046
-version: 1.0.3
+version: 1.0.4

--- a/include/esp_lcd_touch_xpt2046.h
+++ b/include/esp_lcd_touch_xpt2046.h
@@ -172,15 +172,50 @@ esp_err_t esp_lcd_touch_new_spi_xpt2046(const esp_lcd_panel_io_handle_t io,
 
 /**
  * @brief Reads the voltage from the v-bat pin of the XPT2046.
- * 
+ *
  * @param handle: XPT2046 instance handle.
  * @param out_level: Approximate voltage read in from the v-bat pin.
  * @return
  *      - ESP_OK on success, otherwise returns ESP_ERR_xxx
- * 
+ *
  * @note The v-bat pin has a voltage range of 0.0 to 6.0 volts.
  */
 esp_err_t esp_lcd_touch_xpt2046_read_battery_level(const esp_lcd_touch_handle_t handle, float *out_level);
+
+/**
+ * @brief Reads the voltage from the aux pin of the XPT2046.
+ *
+ * @param handle: XPT2046 instance handle.
+ * @param out_level: Approximate voltage read in from the aux pin.
+ * @return
+ *      - ESP_OK on success, otherwise returns ESP_ERR_xxx
+ *
+ * @note The aux pin has a voltage range of 0.0 to 2.5 volts.
+ */
+esp_err_t esp_lcd_touch_xpt2046_read_aux_level(const esp_lcd_touch_handle_t handle, float *out_level);
+
+/**
+ * @brief Reads the temperature from the XPT2046 using a one-point reading.
+ *        High precision (0.3 degrees C) but low accuracy requires a
+ *        calibration offset for accurate results.
+ *
+ * @param handle: XPT2046 instance handle.
+ * @param out_level: Approximate tempreature of the TSC2046 in degrees C
+ * @return
+ *      - ESP_OK on success, otherwise returns ESP_ERR_xxx
+ */
+esp_err_t esp_lcd_touch_xpt2046_read_temp0_level(const esp_lcd_touch_handle_t handle, float *output);
+
+/**
+ * @brief Reads the temperature from the XPT2046 using a two-point reading.
+ *        Low precision (1.6 degrees C) but high accuracy requires no calibration.
+ *
+ * @param handle: XPT2046 instance handle.
+ * @param out_level: Approximate tempreature of the TSC2046 in degrees C
+ * @return
+ *      - ESP_OK on success, otherwise returns ESP_ERR_xxx
+ */
+esp_err_t esp_lcd_touch_xpt2046_read_temp1_level(const esp_lcd_touch_handle_t handle, float *output);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds the following capabilities:

- Read the Aux Input pin
- Read the temperature using the TEMP0 register (one point mode)
- Read the temperature using the TEMP1 register (two point mode)
- Enable PENIRQ pin option. ~~(Note: Can't use this in the driver to check for touch, but can enable the output from the chip)~~
- Enable Vref ON option. (Leaves the Vref permanently on to reduce transactions when reading battery/aux/temperature

It also fixes the following issues:

- The battery voltage value wasn't being right-shifted by 3 so was 8 times too large.
- Vref is approx 2.507V, not 2.500V (you need to look at the internal Vref vs temperature graph in the datasheet to find that, between 5C and 40C it's above 2.507V, and still above 2.505V between -25C and 65C, which is basically the normal range)
- Fixes co-ordinate averaging.
  - The bug:
    - If the screen press is released while the averaging loop is being run, some co-ordinates with value 0 get introduced into the average.
    - This means that instead of the averaged coordinate value being the press location, it is 'torn' between the press location and the corner of the screen (coordinate 0,0)
    - Because this happens on a press release, it results in a 'click' action in a completely different location than the press.
    - This is more likely to occur the more frequently the touch panel is sampled
  - The fix:
    - Sanity check every input coordinate pair while looping
    - Count how many coordinate pairs were valid
    - Check there were sufficient valid coordinate pairs (at least 1, and >= 50%)
    - Average only the valid coordinate pairs

Tested on IDF v5.2.1 with a TSC2048 (the TI chip which the XPT2046 cloned)