### PR TITLE
Fix Interrupt mode

### DIFF
--- a/esp_lcd_touch_xpt2046.c
+++ b/esp_lcd_touch_xpt2046.c
@@ -118,6 +118,13 @@ esp_err_t esp_lcd_touch_new_spi_xpt2046(const esp_lcd_panel_io_handle_t io,
         {
             esp_lcd_touch_register_interrupt_callback(handle, config->interrupt_callback);
         }
+
+#if CONFIG_XPT2046_INTERRUPT_MODE
+        // Read a register to enable Low Power mode, which is required for interrupt to work.
+        uint8_t battery = 0;
+        ESP_GOTO_ON_ERROR(esp_lcd_panel_io_rx_param(handle->io, BATTERY, &battery, 1), err, TAG, "XPT2046 read error!");
+#endif
+
     }
 
 err:


### PR DESCRIPTION
Hi there. I was getting started with the ESP32 Cheap Yellow Display based on this example:
https://github.com/witnessmenow/ESP32-Cheap-Yellow-Display/tree/main/Examples/ESP-IDF/LVGL9

The display works as expected but the touch didn't work. After finally reading the XPT2046, I realized that its interrupt mode only works in low power mode. In the LVGL integration, interrupt mode is used, but there isn't a single read operation that would enable low power mode.

This PR reads the battery level to enable low power mode if CONFIG_XPT2046_INTERRUPT_MODE is enabled.